### PR TITLE
Setting flag to use UUIDs - (Task #191)

### DIFF
--- a/de.dlr.sc.virsat.model.extension.fdir.ui/src/de/dlr/sc/virsat/model/extension/fdir/ui/wizards/ExportGalileoDFTWizard.java
+++ b/de.dlr.sc.virsat.model.extension.fdir.ui/src/de/dlr/sc/virsat/model/extension/fdir/ui/wizards/ExportGalileoDFTWizard.java
@@ -66,7 +66,7 @@ public class ExportGalileoDFTWizard extends Wizard implements INewWizard {
 		// grab an input
 		String path = page.getDestination();
 		try {
-			DFT2GalileoDFT converter = new DFT2GalileoDFT();
+			DFT2GalileoDFT converter = new DFT2GalileoDFT(false);
 			GalileoDft galileoDft = converter.convert(sei);
 			new GalileoDFTWriter(path).write(galileoDft);
 			return true;

--- a/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/converter/DFT2GalileoDFT.java
+++ b/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/converter/DFT2GalileoDFT.java
@@ -28,6 +28,7 @@ import de.dlr.sc.virsat.model.extension.fdir.model.FaultTreeNode;
 import de.dlr.sc.virsat.model.extension.fdir.model.FaultTreeNodeType;
 import de.dlr.sc.virsat.model.extension.fdir.model.Gate;
 import de.dlr.sc.virsat.model.extension.fdir.model.MONITOR;
+import de.dlr.sc.virsat.model.extension.fdir.model.SPARE;
 import de.dlr.sc.virsat.model.extension.fdir.model.VOTE;
 import de.dlr.sc.virsat.model.extension.fdir.util.FaultTreeHelper;
 
@@ -96,6 +97,8 @@ public class DFT2GalileoDFT {
 				if (node instanceof VOTE) {
 					VOTE vote = (VOTE) node;
 					nodeType.setTypeName(vote.getVotingThreshold() + "of" +  ftHelper.getChildren(vote).size());
+				} else if (node instanceof SPARE) {
+					nodeType.setTypeName("wsp");
 				} else {
 					nodeType.setTypeName(gate.getFaultTreeNodeType().toString().toLowerCase());
 				}


### PR DESCRIPTION
- Setting UUID flag for Galileo DFT export.
- Fixed a small bug regaridng export of spare gates

---
Task #191: Use UUIDs instead of Fullqualifiednames for Galileo DFT
export