### PR TITLE
Disabled symmetry reduction for reduced failables - (Task #205)

### DIFF
--- a/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/converter/dft2ma/semantics/DFTSemantics.java
+++ b/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/converter/dft2ma/semantics/DFTSemantics.java
@@ -63,11 +63,11 @@ public class DFTSemantics {
 		Set<IDFTEvent> faultEvents = new HashSet<>();
 		
 		for (BasicEvent be : ftHolder.getMapBasicEventToFault().keySet()) {
-			if (allowsRepairEvents && be.isSetRepairRate() && be.getRepairRate() > 0) {
+			if (allowsRepairEvents && be.isSetRepairRate() && be.getRepairRate() != 0) {
 				faultEvents.add(new FaultEvent(be, true, ftHolder));					
 			}
 			
-			if (be.isSetHotFailureRate() && be.getHotFailureRate() > 0) {
+			if (be.isSetHotFailureRate() && be.getHotFailureRate() != 0) {
 				faultEvents.add(new FaultEvent(be, false, ftHolder));
 			}
 		}

--- a/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/evaluator/DFTEvaluator.java
+++ b/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/evaluator/DFTEvaluator.java
@@ -82,7 +82,7 @@ public class DFTEvaluator implements IFaultTreeEvaluator {
 		statistics.time = System.currentTimeMillis();
 		
 		FaultTreeHolder ftHolder = new FaultTreeHolder(root);
-		configureDFT2MAConverter(ftHolder, metrics);
+		configureDFT2MAConverter(ftHolder, metrics, failableBasicEventsProvider);
 		
 		DFTModularization modularization = getModularization(ftHolder, failableBasicEventsProvider);
 		
@@ -178,10 +178,11 @@ public class DFTEvaluator implements IFaultTreeEvaluator {
 	
 	/**
 	 * Configures the state space generator
-	 * @param ftHolder the fault ree to convert
+	 * @param ftHolder the fault tree to convert
 	 * @param metrics the metrics to evaluate
+	 * @param failableBasicEventsProvider the basic events provider
 	 */
-	private void configureDFT2MAConverter(FaultTreeHolder ftHolder, IMetric[] metrics) {
+	private void configureDFT2MAConverter(FaultTreeHolder ftHolder, IMetric[] metrics, FailableBasicEventsProvider failableBasicEventsProvider) {
 		dft2MAConverter.setSemantics(chooseSemantics(ftHolder));
 		dft2MAConverter.setRecoveryStrategy(recoveryStrategy);
 		dft2MAConverter.getDftSemantics().setAllowsRepairEvents(!hasQualitativeMetric(metrics));
@@ -192,6 +193,10 @@ public class DFTEvaluator implements IFaultTreeEvaluator {
 		} else {
 			dft2MAConverter.setSymmetryChecker(new FaultTreeSymmetryChecker());
 			dft2MAConverter.setAllowsDontCareFailing(true);
+		}
+		
+		if (failableBasicEventsProvider != null) {
+			dft2MAConverter.setSymmetryChecker(null);
 		}
 	}
 	

--- a/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/util/FaultTreeHelper.java
+++ b/de.dlr.sc.virsat.model.extension.fdir/src/de/dlr/sc/virsat/model/extension/fdir/util/FaultTreeHelper.java
@@ -422,9 +422,21 @@ public class FaultTreeHelper {
 
 		for (BasicEvent fm : fault.getBasicEvents()) {
 			BasicEvent newFm = new BasicEvent(concept);
-			newFm.getHotFailureRateBean().setValueAsBaseUnit(fm.getHotFailureRateBean().getValueToBaseUnit());
-			newFm.getColdFailureRateBean().setValueAsBaseUnit(fm.getColdFailureRateBean().getValueToBaseUnit());
-			newFm.getRepairRateBean().setValueAsBaseUnit(fm.getRepairRateBean().getValueToBaseUnit());
+			try {
+				newFm.getHotFailureRateBean().setValueAsBaseUnit(fm.getHotFailureRateBean().getValueToBaseUnit());
+			} catch (NullPointerException e) {
+				newFm.getHotFailureRateBean().setValueAsBaseUnit(Double.NaN);
+			}
+			try {
+				newFm.getColdFailureRateBean().setValueAsBaseUnit(fm.getColdFailureRateBean().getValueToBaseUnit());
+			} catch (NullPointerException e) {
+				newFm.getColdFailureRateBean().setValueAsBaseUnit(Double.NaN);
+			}
+			try {
+				newFm.getRepairRateBean().setValueAsBaseUnit(fm.getRepairRateBean().getValueToBaseUnit());
+			} catch (NullPointerException e) {
+				newFm.getRepairRateBean().setValueAsBaseUnit(Double.NaN);
+			}
 			newFm.setName(fm.getName());
 			newFm.getTypeInstance().setUuid(fm.getTypeInstance().getUuid());
 			copy.getBasicEvents().add(newFm);


### PR DESCRIPTION
- When checking a fault tree with a restricted set of failable events,
the symmetry reduction is now disabled.

Closes #205

---
Task #205: MTTF for MinCut analysis shows infinite time for mincuts
using spares